### PR TITLE
Don't clean before deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ matrix:
 #                tags: true
         # Development deploy on master commits
           - provider: script
+            skip_cleanup: true
             script: bash deploy_dev.sh
             on:
                 branch: master


### PR DESCRIPTION
Travis has an issue when trying to git stash our frontend for some reason. It gets stuck unstashing a ton of node files and clogs up the log right after the deploy goes through.
Not cleaning the frontend build folder before deploy makes travis deploys quicker and un-breaks the travis log.