### PR TITLE
Add new endpoints for members and signups

### DIFF
--- a/back/pyproject.toml
+++ b/back/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tmeit_backend"
-version = "0.5.8"
+version = "0.6.0"
 description = "Python backend for the TMEIT website"
 authors = ["TraditionsMEsterIT"]
 license = "AGPL-3.0"

--- a/back/tests/test_schemas.py
+++ b/back/tests/test_schemas.py
@@ -1,0 +1,17 @@
+from tmeit_backend.schemas.members import schemas
+from tmeit_backend.schemas.access_levels import APIAccessLevelsEnum
+
+
+def test_read_memberschema():
+    properties = schemas.MemberMemberView.schema()['properties']
+    readable_fields = set(schemas.database_fields_schema_dict) \
+        | {field for field, perms in schemas.member_fields.items() if perms['member'] in (APIAccessLevelsEnum.edit, APIAccessLevelsEnum.read)}
+    assert set(properties.keys()) == readable_fields  # Correct fields are included
+
+
+def test_patch_memberschema():
+    properties = schemas.MemberSelfPatch.schema()['properties']
+    writable_fields = {field for field, perms in schemas.member_fields.items() if perms['self'] == APIAccessLevelsEnum.edit}
+    assert set(properties.keys()) == writable_fields  # Correct fields are included
+    assert 'required' not in schemas.MemberSelfPatch.schema() # All fields are Optional
+

--- a/back/tmeit_backend/crud/members.py
+++ b/back/tmeit_backend/crud/members.py
@@ -83,17 +83,16 @@ async def update_member(db: AsyncSession,
                         short_uuid: str,
                         patch_data: MemberSelfPatch | MemberMasterPatch,
                         response_schema: Type[S]) -> S:
-    result = (await db.execute(
-        update(models.Member)
-        .where(models.Member.short_uuid == short_uuid)
-        .values(**patch_data.dict())
-        .returning('*')
-    )).fetchone()
+    async with db.begin():
+        result = (await db.execute(
+            update(models.Member)
+            .where(models.Member.short_uuid == short_uuid)
+            .values(**patch_data.dict())
+            .returning('*')
+        )).fetchone()
 
-    if result is None:
-        raise KeyError()
-
-    await db.commit()
+        if result is None:
+            raise KeyError()
 
     sql_member = result._asdict()
     sql_member['role_histories'] = []

--- a/back/tmeit_backend/crud/sign_up.py
+++ b/back/tmeit_backend/crud/sign_up.py
@@ -70,13 +70,14 @@ async def get_sign_up(db: AsyncSession, uuid: UUID) -> SignUp:
 
 
 async def approve_sign_up(db: AsyncSession, uuid: UUID) -> MemberMasterView:
-    stmt = select(models.SignUp).where(models.SignUp.uuid == str(uuid))
-    result = (await db.execute(stmt)).fetchone()
-    if result is None:
-        raise KeyError()
-    sql_signup: models.SignUp = result.SignUp
-    uuid = uuid4()
     async with db.begin():
+        stmt = select(models.SignUp).where(models.SignUp.uuid == str(uuid))
+        result = (await db.execute(stmt)).fetchone()
+        if result is None:
+            raise KeyError()
+        sql_signup: models.SignUp = result.SignUp
+
+        uuid = uuid4()
         db.add_all([
             models.Member(uuid=str(uuid),
                           login_email=sql_signup.login_email,
@@ -87,13 +88,14 @@ async def approve_sign_up(db: AsyncSession, uuid: UUID) -> MemberMasterView:
             # TODO: We should also add a RoleHistory here with the prao signup date
         ])
         await db.delete(sql_signup)
+
     return await get_member(db=db, uuid=uuid, response_schema=MemberMasterView)
 
 
 async def delete_sign_up(db: AsyncSession, uuid: UUID) -> None:
-    stmt = select(models.SignUp).where(models.SignUp.uuid == str(uuid))
-    result = (await db.execute(stmt)).fetchone()
-    if result is None:
-        raise KeyError()
     async with db.begin():
+        stmt = select(models.SignUp).where(models.SignUp.uuid == str(uuid))
+        result = (await db.execute(stmt)).fetchone()
+        if result is None:
+            raise KeyError()
         await db.delete(result.SignUp)

--- a/back/tmeit_backend/crud/sign_up.py
+++ b/back/tmeit_backend/crud/sign_up.py
@@ -2,6 +2,7 @@ import ipaddress
 from typing import Union
 from uuid import UUID, uuid4
 
+from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
@@ -15,17 +16,30 @@ from ..schemas.sign_up import SignUp, SignUpForm
 
 async def sign_up(db: AsyncSession, data: SignUpForm,
                   ip_address: Union[ipaddress.IPv4Address, ipaddress.IPv6Address]) -> SignUp:
-    uuid = uuid4()
-    hashed_password = ph.hash(data.password)
-    match ip_address:
-        case ipaddress.IPv6Address():
-            ip = str(ip_address)
-        case ipaddress.IPv4Address():  # Convert IPv4 address to an IPv4-Mapped IPv6 Address
-            ip_bytes = b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff' + ip_address.packed
-            ip = str(ipaddress.IPv6Address(ip_bytes))
-        case _:
-            raise ValueError("Invalid IP address!")
     async with db.begin():
+        # Make sure no members or signups exist with the same email
+        email = data.login_email
+        dupe_signups = await db.execute(select(func.count(models.SignUp.uuid)).where(models.SignUp.login_email == email))
+        dupe_members = await db.execute(select(func.count(models.Member.uuid)).where(models.Member.login_email == email))
+        if dupe_signups.scalar() > 0:
+            raise ValueError(f"A signup already exists with the {email=}.")
+            # TODO: Ideally we would tell them: "Have you already signed up? Check your email!"
+        if dupe_members.scalar() > 0:
+            raise ValueError(f"A member already exists with the {email=}.")
+
+        # Compute uuid, hash, and ip address
+        uuid = uuid4()
+        hashed_password = ph.hash(data.password)
+        match ip_address:
+            case ipaddress.IPv6Address():
+                ip = str(ip_address)
+            case ipaddress.IPv4Address():  # Convert IPv4 address to an IPv4-Mapped IPv6 Address
+                ip_bytes = b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff' + ip_address.packed
+                ip = str(ipaddress.IPv6Address(ip_bytes))
+            case _:
+                raise ValueError("Invalid IP address!")
+
+        # Add new row
         db.add_all([
             models.SignUp(uuid=str(uuid),
                           login_email=data.login_email,
@@ -35,6 +49,7 @@ async def sign_up(db: AsyncSession, data: SignUpForm,
                           last_name=data.last_name,
                           phone=data.phone),
         ])
+
     return await get_sign_up(db=db, uuid=uuid)
 
 

--- a/back/tmeit_backend/crud/sign_up.py
+++ b/back/tmeit_backend/crud/sign_up.py
@@ -75,7 +75,7 @@ async def approve_sign_up(db: AsyncSession, uuid: UUID) -> MemberMasterView:
     return await get_member(db=db, uuid=uuid, response_schema=MemberMasterView)
 
 
-async def delete_sign_up(db: AsyncSession, uuid: UUID) -> MemberMasterView:
+async def delete_sign_up(db: AsyncSession, uuid: UUID) -> None:
     stmt = select(models.SignUp).where(models.SignUp.uuid == str(uuid))
     result = (await db.execute(stmt)).fetchone()
     if result is None:

--- a/back/tmeit_backend/routers/_error_responses.py
+++ b/back/tmeit_backend/routers/_error_responses.py
@@ -1,3 +1,5 @@
+from typing import Literal, Any
+
 from pydantic import BaseModel
 
 
@@ -7,3 +9,8 @@ class NotFoundResponse(BaseModel):
 
 class ForbiddenResponse(BaseModel):
     error: str
+
+
+class BadPatchResponse(BaseModel):
+    error: Literal["Invalid fields, or you don't have permission to edit these fields."]
+    detail: dict[str, Any]

--- a/back/tmeit_backend/routers/_error_responses.py
+++ b/back/tmeit_backend/routers/_error_responses.py
@@ -11,6 +11,10 @@ class ForbiddenResponse(BaseModel):
     error: str
 
 
+class ConflictResponse(BaseModel):
+    error: str
+
+
 class BadPatchResponse(BaseModel):
     error: Literal["Invalid fields, or you don't have permission to edit these fields."]
     detail: dict[str, Any]

--- a/back/tmeit_backend/routers/members.py
+++ b/back/tmeit_backend/routers/members.py
@@ -20,7 +20,7 @@ class NotLoggedInResponse(BaseModel):
     detail: Literal["You are not logged in."]
 
 
-@router.get("/", response_model=list[Union[MemberPublicView, MemberMemberView, MemberMasterView]])
+@router.get("/", response_model=list[Union[MemberMasterView, MemberMemberView, MemberPublicView]])
 async def read_members(db: AsyncSession = Depends(get_db),
                        current_user: MemberSelfView = Depends(get_current_user)):
 
@@ -80,7 +80,7 @@ async def create_new_member(member_data: MemberMasterCreate,
 
 
 @router.patch("/{short_uuid}",
-              response_model=MemberSelfView | MemberMasterView,
+              response_model=MemberMasterView | MemberSelfView,
               responses={401: {"model": NotLoggedInResponse},
                          403: {"model": ForbiddenResponse},
                          404: {"model": NotFoundResponse}})

--- a/back/tmeit_backend/routers/members.py
+++ b/back/tmeit_backend/routers/members.py
@@ -8,9 +8,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ._database_deps import get_db, get_current_user
 from ._error_responses import NotFoundResponse, ForbiddenResponse
-from ..crud.members import get_members, get_member_by_short_uuid, create_member
+from ..crud.members import get_members, get_member_by_short_uuid, create_member, update_member
 from ..schemas.members.schemas import base64url_length_8, MemberMemberView, MemberSelfView, MemberPublicView, \
-    MemberMasterView, MemberMasterCreate, MemberViewResponse
+    MemberMasterView, MemberMasterCreate, MemberViewResponse, MemberSelfPatch, MemberMasterPatch
 
 router = APIRouter()
 me_router = APIRouter()
@@ -76,4 +76,48 @@ async def create_new_member(member_data: MemberMasterCreate,
         return JSONResponse(status_code=status.HTTP_403_FORBIDDEN,
                             content={"error": f"Only masters may create new members."})
     member = await create_member(db=db, data=member_data)
+    return member
+
+
+@router.patch("/{short_uuid}",
+              response_model=MemberSelfView | MemberMasterView,
+              responses={401: {"model": NotLoggedInResponse},
+                         403: {"model": ForbiddenResponse},
+                         404: {"model": NotFoundResponse}})
+async def patch_member(short_uuid: base64url_length_8,
+                       field_data: MemberMasterPatch,
+                       db: AsyncSession = Depends(get_db),
+                       current_user: MemberSelfView = Depends(get_current_user)):
+    """Updates data for a Member. Only the fields specified will be updated."""
+
+    # Ensure user is logged in
+    if current_user is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED,
+                            detail="You are not logged in.",
+                            headers={"WWW-Authenticate": "Bearer"})
+
+    # Check authentication level
+    if current_user.current_role == "master":
+        response_schema = MemberMasterView
+        patch_schema = MemberMasterPatch
+    elif current_user.short_uuid == short_uuid:
+        response_schema = MemberSelfView
+        patch_schema = MemberSelfPatch
+    else:
+        return JSONResponse(status_code=status.HTTP_403_FORBIDDEN,
+                            content={"error": f"You don't have permission to edit this user."})
+
+    # Ensure user has permission to set that field
+    try:
+        validated_data = patch_schema.parse_obj(field_data)
+    except Exception as e:
+        traceback.print_exc()
+        return JSONResponse(status_code=status.HTTP_403_FORBIDDEN,
+                            content={"error": f"You don't have permission to edit this user."})
+
+    try:
+        member = await update_member(db=db, short_uuid=short_uuid, patch_data=validated_data, response_schema=response_schema)
+    except KeyError:
+        return JSONResponse(status_code=status.HTTP_404_NOT_FOUND,
+                            content={"error": f"No member with the {short_uuid=} was found."})
     return member

--- a/back/tmeit_backend/routers/sign_up.py
+++ b/back/tmeit_backend/routers/sign_up.py
@@ -34,9 +34,11 @@ async def read_sign_ups(db: AsyncSession = Depends(get_db),
     return await get_sign_ups(db=db)
 
 
-@router.get("/{uuid}", response_model=MemberViewResponse, responses={404: {"model": NotFoundResponse}})
+@router.get("/{uuid}", response_model=SignUp, responses={404: {"model": NotFoundResponse}})
 async def read_sign_up(uuid: UUID,
                        db: AsyncSession = Depends(get_db)):
+
+    # We allow anyone with the signup UUID to view the signup, so that prao can see their signup status page
 
     try:
         member = await get_sign_up(db=db, uuid=uuid)

--- a/back/tmeit_backend/routers/sign_up.py
+++ b/back/tmeit_backend/routers/sign_up.py
@@ -11,6 +11,8 @@ from ._database_deps import get_db, get_current_user
 from ._error_responses import NotFoundResponse, ForbiddenResponse, ConflictResponse
 from ..crud.sign_up import get_sign_up, get_sign_ups
 from ..crud.sign_up import sign_up as sign_up_crud
+from ..crud.sign_up import delete_sign_up as delete_sign_up_crud
+from ..crud.sign_up import approve_sign_up as approve_sign_up_crud
 from ..schemas.members.schemas import base64url_length_8, MemberMemberView, MemberSelfView, MemberPublicView, \
     MemberMasterView, MemberMasterCreate, MemberViewResponse
 from ..schemas.sign_up import SignUp, SignUpForm
@@ -57,7 +59,7 @@ async def delete_sign_up(uuid: UUID,
         return JSONResponse(status_code=status.HTTP_403_FORBIDDEN,
                             content={"error": f"Only masters may delete a pending sign-up."})
     try:
-        await delete_sign_up(db=db, uuid=uuid)
+        await delete_sign_up_crud(db=db, uuid=uuid)
     except KeyError:
         return JSONResponse(status_code=status.HTTP_404_NOT_FOUND,
                             content={"error": f"No signup with the {uuid=} was found."})
@@ -73,7 +75,7 @@ async def approve_sign_up(uuid: UUID,
                             content={"error": f"Only masters may approve a pending sign-up."})
 
     try:
-        member = await approve_sign_up(db=db, uuid=uuid)
+        member = await approve_sign_up_crud(db=db, uuid=uuid)
     except KeyError:
         return JSONResponse(status_code=status.HTTP_404_NOT_FOUND,
                             content={"error": f"No signup with the {uuid=} was found."})

--- a/back/tmeit_backend/schemas/members/schemas.py
+++ b/back/tmeit_backend/schemas/members/schemas.py
@@ -119,7 +119,7 @@ MemberMasterPatch = create_model('MemberMasterPatch', **build_member_schema_dict
 # Create models
 MemberMasterCreate = create_model('MemberMasterCreate', **build_member_schema_dict("master", edit))
 
-MemberViewResponse = Union[MemberPublicView, MemberMemberView, MemberSelfView, MemberMasterView]
+MemberViewResponse = Union[MemberMasterView, MemberSelfView, MemberMemberView, MemberPublicView]
 
 
 class MemberAuthentication(BaseModel):

--- a/back/tmeit_backend/schemas/members/schemas.py
+++ b/back/tmeit_backend/schemas/members/schemas.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import TypedDict, Any, Literal, Union, Optional
+from typing import TypedDict, Any, Literal, Union, Optional, NamedTuple
 from uuid import UUID
 
 from pydantic import EmailStr, constr, create_model, Field, BaseModel
@@ -13,12 +13,14 @@ from .enums import CurrentRoleEnum
 # (e.g. don't return email in api if user is unauthenticated)
 
 
+# permission level aliases
 edit = APIAccessLevelsEnum.edit
 read = APIAccessLevelsEnum.read
 denied = APIAccessLevelsEnum.denied
 
 
 class FieldDescription(TypedDict):
+    """Type that we use to define a field and its different permissions"""
 
     # API permission levels
     master: APIAccessLevelsEnum     # API user is a Master/admin
@@ -30,7 +32,15 @@ class FieldDescription(TypedDict):
     type: Any
 
 
-member_fields = {
+FieldDict = dict[str, FieldDescription]
+
+
+class FieldTuple(NamedTuple):
+    field_type: Any
+    default_value: Optional[Any]
+
+
+member_fields: FieldDict = {
 
     # Publicly visible fields
     "first_name":       FieldDescription(master=edit,   self=read,  member=read,    public=read,    type=str),
@@ -62,33 +72,49 @@ base64url_length_8 = constr(min_length=8, max_length=8, regex=r'[A-Za-z0-9\-_]{8
 
 def build_member_schema_dict(
         permission_role: Literal["master"] | Literal["self"] | Literal["member"] | Literal["public"],
-        api_access_level: APIAccessLevelsEnum) -> dict[str, tuple]:
+        api_access_level: APIAccessLevelsEnum,
+        all_fields_optional: bool = False) -> dict[str, FieldTuple]:
 
-    schema_dict: dict[str, tuple] = {}
+    schema_dict: dict[str, FieldTuple] = {}
 
-    for field, fd in member_fields.items():
-        if fd[permission_role] >= api_access_level:
-            schema_dict[field] = (fd['type'], Field(...))
+    for field_name, fd in member_fields.items():
+        field_name: str
+        fd: FieldDescription
+
+        if fd[permission_role] >= api_access_level:  # Check permission level
+
+            # Make all fields optional for patch schemas, since our PATCH endpoints only take 1 field
+            if all_fields_optional is True:
+                type = Optional[fd['type']]
+            else:
+                type = fd['type']
+
+            # Add field to schema dict
+            schema_dict[field_name] = FieldTuple(type, None)
 
     return schema_dict
 
 
 # Always include uuid and short uuid in api requests/responses
-database_fields = {
+database_fields_schema_dict = {
     "uuid": (UUID, Field(...)),
     "short_uuid": (base64url_length_8, Field(...)),
 }
 
+
+# Create Member models programmatically from our schema dicts
+# https://pydantic-docs.helpmanual.io/usage/models/#dynamic-model-creation
+
 # View models
-MemberPublicView = create_model('MemberPublicView', **database_fields, **build_member_schema_dict("public", read))
-MemberMemberView = create_model('MemberMemberView', **database_fields, **build_member_schema_dict("member", read))
-MemberSelfView = create_model('MemberSelfView', **database_fields, **build_member_schema_dict("self", read))
-MemberMasterView = create_model('MemberMasterView', **database_fields, **build_member_schema_dict("master", read))
+MemberPublicView = create_model('MemberPublicView', **database_fields_schema_dict, **build_member_schema_dict("public", read))
+MemberMemberView = create_model('MemberMemberView', **database_fields_schema_dict, **build_member_schema_dict("member", read))
+MemberSelfView = create_model('MemberSelfView', **database_fields_schema_dict, **build_member_schema_dict("self", read))
+MemberMasterView = create_model('MemberMasterView', **database_fields_schema_dict, **build_member_schema_dict("master", read))
 
 
-# Edit models
-MemberSelfPatch = create_model('MemberSelfPatch', **database_fields, **build_member_schema_dict("self", edit))
-MemberMasterPatch = create_model('MemberMasterPatch', **database_fields, **build_member_schema_dict("master", edit))
+# Patch models
+MemberSelfPatch = create_model('MemberSelfPatch', **build_member_schema_dict("self", edit, all_fields_optional=True))
+MemberMasterPatch = create_model('MemberMasterPatch', **build_member_schema_dict("master", edit, all_fields_optional=True))
 
 # Create models
 MemberMasterCreate = create_model('MemberMasterCreate', **build_member_schema_dict("master", edit))

--- a/back/tmeit_backend/testing_data/populate_db.py
+++ b/back/tmeit_backend/testing_data/populate_db.py
@@ -26,12 +26,12 @@ def random_date(start_date: datetime.date, stop_date: datetime.date) -> datetime
     return start_date + delta
 
 
-def create_member(hashed_password) -> Member:
+def create_member(hashed_password, email_number) -> Member:
     first_name = random.choice(first_names)
     last_name = random.choice(last_names)
     return Member(
         uuid=str(uuid4()),
-        login_email=f"{random.randint(10000000, 99999999)}@kth.se",
+        login_email=f"{email_number}@kth.se",
         hashed_password=hashed_password,
         current_role=CurrentRoleEnum.master.value,
         first_name=first_name,
@@ -48,7 +48,7 @@ def create_member(hashed_password) -> Member:
 async def create_members(number: int, db: AsyncSession) -> None:
     hashed_password = auth.ph.hash('yeet')
 
-    members: list[Member] = [create_member(hashed_password) for _ in range(number)]
+    members: list[Member] = [create_member(hashed_password, i) for i in range(number)]
 
     async with db.begin():
         db.add_all(members)

--- a/deploy/tmeit-jlh-name/run-migrations/set_image_tag.json
+++ b/deploy/tmeit-jlh-name/run-migrations/set_image_tag.json
@@ -2,6 +2,6 @@
   {
     "op": "replace",
     "path": "/spec/template/spec/containers/0/image",
-    "value": "ghcr.io/tmeit/tmeit-run-migrations:0.5.8"
+    "value": "ghcr.io/tmeit/tmeit-run-migrations:0.6.0"
   }
 ]

--- a/deploy/tmeit-jlh-name/tmeit-app/set_image_tag.json
+++ b/deploy/tmeit-jlh-name/tmeit-app/set_image_tag.json
@@ -2,6 +2,6 @@
   {
     "op": "replace",
     "path": "/spec/template/spec/containers/0/image",
-    "value": "ghcr.io/tmeit/tmeit-app:0.5.8"
+    "value": "ghcr.io/tmeit/tmeit-app:0.6.0"
   }
 ]

--- a/front/package.json
+++ b/front/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tmeit-frontend",
-  "version": "0.5.8",
+  "version": "0.6.0",
   "description": "Front-end for the TMEIT website.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Added: You can now PATCH members to change fields on that member, if you have the permission to do so.

Added: Masters can now DELETE signups

Fixed: New signups now check if a member already exists with that email, and give a better error message if a signup was already created with that email.

Added: Masters can now approve a pending signup, which creates a member from that signup, and deletes the signup.