### PR TITLE
Fix Terraform credential error

### DIFF
--- a/.github/workflows/publish-master.yaml
+++ b/.github/workflows/publish-master.yaml
@@ -27,7 +27,9 @@ jobs:
       - uses: actions/checkout@v3
 
       # https://learn.hashicorp.com/tutorials/terraform/github-actions?in=terraform/automation
-      - uses: hashicorp/setup-terraform@v2
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.7.5"
       - name: Terraform Init
         run: terraform init
         working-directory: deploy/terraform
@@ -41,9 +43,10 @@ jobs:
         id: tf_ip_addr
         run: terraform output -raw ipv4_address
         working-directory: deploy/terraform
-      - uses: hashicorp/setup-terraform@v2  # Remove wrapper so that we can output directly to files
+      - uses: hashicorp/setup-terraform@v3
         with:
-          terraform_wrapper: false
+          terraform_version: "1.7.5"
+          terraform_wrapper: false  # Remove wrapper so that we can output directly to files
       - name: Get Cloudflare token for Let's Encrypt
         id: tf_cf_le_token
         run: terraform output -raw cloudflare-le-token > ../kubernetes/tmeit-se/certificate/cloudflare-api-token

--- a/.github/workflows/publish-master.yaml
+++ b/.github/workflows/publish-master.yaml
@@ -178,7 +178,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: deploy # Run after deploy so that we can get the docker image for publishing
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
       - uses: actions/setup-python@v3

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Are version numbers incremented
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.2.0
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Required due to get git tag list due to the way Git works
       - uses: actions/setup-python@v3
@@ -23,7 +23,7 @@ jobs:
     name: Lint GH Actions workflows
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.2.0
+      - uses: actions/checkout@v4
       - uses: reviewdog/action-actionlint@v1
   plan-terraform: # https://learn.hashicorp.com/tutorials/terraform/github-actions?in=terraform/automation
     name: Run Terraform Validate and Plan
@@ -122,7 +122,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: plan-terraform  # Needs kubeconfig from terraform
     steps:
-      - uses: actions/checkout@v2.2.0
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v3
         with:
           python-version: '3.10'
@@ -152,7 +152,7 @@ jobs:
     name: Build app containers
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.2.0
+      - uses: actions/checkout@v4
       - name: Build containers
         uses: redhat-actions/buildah-build@v2
         with:
@@ -167,7 +167,7 @@ jobs:
     name: Test app
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.2.0
+      - uses: actions/checkout@v4
       - name: Build test container
         uses: redhat-actions/buildah-build@v2
         with:
@@ -188,7 +188,7 @@ jobs:
             POSTGRES_DB: tmeit_backend
           options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
       steps:
-        - uses: actions/checkout@v2.2.0
+        - uses: actions/checkout@v4
         - name: Build tester container
           run: |
             docker build . -f containerfiles/create-test-db.Containerfile -t create-test-db

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -38,7 +38,9 @@ jobs:
       TF_VAR_pw_hash: ${{ secrets.NODE_ROOT_USER_PW_HASH }}
     steps:
       - uses: actions/checkout@v3
-      - uses: hashicorp/setup-terraform@v2
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.7.5"
       - id: fmt
         run: terraform fmt -check
       - id: init
@@ -91,8 +93,9 @@ jobs:
         id: tf_ip_addr
         run: terraform output -raw ipv4_address
         working-directory: deploy/terraform
-      - uses: hashicorp/setup-terraform@v2
+      - uses: hashicorp/setup-terraform@v3
         with:
+          terraform_version: "1.7.5"
           terraform_wrapper: false
       - name: Get SSH key
         run: terraform output -raw ssh_key > "$HOME/id_ed25519"

--- a/back/pyproject.toml
+++ b/back/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tmeit_backend"
-version = "1.3.1"
+version = "1.3.2"
 description = "Python backend for the TMEIT website"
 authors = ["TraditionsMEsterIT"]
 license = "AGPL-3.0"

--- a/deploy/kubernetes/tmeit-se/postgres/set_image_tag.json
+++ b/deploy/kubernetes/tmeit-se/postgres/set_image_tag.json
@@ -2,6 +2,6 @@
   {
     "op": "replace",
     "path": "/spec/jobTemplate/spec/template/spec/containers/0/image",
-    "value": "ghcr.io/tmeit/db-backup-agent:1.3.1"
+    "value": "ghcr.io/tmeit/db-backup-agent:1.3.2"
   }
 ]

--- a/deploy/kubernetes/tmeit-se/run-migrations/set_image_tag.json
+++ b/deploy/kubernetes/tmeit-se/run-migrations/set_image_tag.json
@@ -2,6 +2,6 @@
   {
     "op": "replace",
     "path": "/spec/template/spec/containers/0/image",
-    "value": "ghcr.io/tmeit/tmeit-run-migrations:1.3.1"
+    "value": "ghcr.io/tmeit/tmeit-run-migrations:1.3.2"
   }
 ]

--- a/deploy/kubernetes/tmeit-se/tmeit-app/set_image_tag.json
+++ b/deploy/kubernetes/tmeit-se/tmeit-app/set_image_tag.json
@@ -2,6 +2,6 @@
   {
     "op": "replace",
     "path": "/spec/template/spec/containers/0/image",
-    "value": "ghcr.io/tmeit/tmeit-app:1.3.1"
+    "value": "ghcr.io/tmeit/tmeit-app:1.3.2"
   }
 ]

--- a/deploy/kubernetes/tmeit-se/tmeit-worker/set_image_tag.json
+++ b/deploy/kubernetes/tmeit-se/tmeit-worker/set_image_tag.json
@@ -2,6 +2,6 @@
   {
     "op": "replace",
     "path": "/spec/template/spec/containers/0/image",
-    "value": "ghcr.io/tmeit/tmeit-worker:1.3.1"
+    "value": "ghcr.io/tmeit/tmeit-worker:1.3.2"
   }
 ]

--- a/front/package.json
+++ b/front/package.json
@@ -3,7 +3,7 @@
   "sideEffects": [
     "*.css"
   ],
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Front-end for the TMEIT website.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Was getting the following error from Github Actions on Terraform 1.9.3:

```
Run terraform init
  terraform init
  shell: /usr/bin/bash -e {0}
  env:
    CLOUDFLARE_API_TOKEN: 
    HCLOUD_TOKEN: 
    AWS_ACCESS_KEY_ID: 
    AWS_SECRET_ACCESS_KEY: 
    B2_APPLICATION_KEY_ID: 
    B2_APPLICATION_KEY: 
    TF_VAR_pw_hash: 
    TERRAFORM_CLI_PATH: /home/runner/work/_temp/1882a3f3-d275-4cb2-b48d-458cb6449c5e
/home/runner/work/_temp/1882a3f3-d275-4cb2-b48d-458cb6449c5e/terraform-bin init
Initializing the backend...
╷
│ Error: No valid credential sources found
│ 
│ Please see https://www.terraform.io/docs/language/settings/backends/s3.html
│ for more information about providing credentials.
│ 
│ Error: failed to refresh cached credentials, no EC2 IMDS role found,
│ operation error ec2imds: GetMetadata, access disabled to EC2 IMDS via
│ client option, or "AWS_EC2_METADATA_DISABLED" environment variable
│ 
╵
Error: Terraform exited with code 1.
Error: Process completed with exit code 1.
```

Reverting to last known working minor version.